### PR TITLE
Update for Crystal 0.32.1

### DIFF
--- a/samples/colorized_prompt.cr
+++ b/samples/colorized_prompt.cr
@@ -1,4 +1,4 @@
-require "../../src/fancyline"
+require "../src/fancyline"
 
 # Demonstration of colorized prompts.
 
@@ -7,7 +7,7 @@ puts "Press Ctrl-C or Ctrl-D to quit."
 
 loop do
   lprompt = "#{Dir.current} ❱❱❱ ".colorize(:blue).mode(:bold).to_s
-  rprompt = "❰❰❰ #{Time.now}".colorize(:yellow).mode(:bold).to_s
+  rprompt = "❰❰❰ #{Time.local}".colorize(:yellow).mode(:bold).to_s
 
   input = fancy.readline(lprompt, rprompt: rprompt)
 

--- a/samples/concurrent_output.cr
+++ b/samples/concurrent_output.cr
@@ -11,7 +11,7 @@ logger.info "Hit Ctrl-D or Ctrl-C to end the demo."
 
 # Simulate a background task writing something onto standard output.
 spawn do
-  loop do |i|
+  0.upto(Int64::MAX).each do |i|
     fancy.grab_output do # Grab the output
       logger.info "Running #{i} seconds..." # Print something
     end

--- a/samples/multiline_prompt.cr
+++ b/samples/multiline_prompt.cr
@@ -1,4 +1,4 @@
-require "../../src/fancyline"
+require "../src/fancyline"
 
 # Demonstration of multi-line prompts.
 

--- a/samples/right_prompt.cr
+++ b/samples/right_prompt.cr
@@ -1,4 +1,4 @@
-require "../../src/fancyline"
+require "../src/fancyline"
 
 # Demonstration of a RPROMPT.  The `rprompt` will be displayed on the right-hand
 # end of the terminal window.

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ dependencies:
     github: Papierkorb/cute
     version: ">= 0.3.1"
 
-crystal: 0.24.1
+crystal: 0.32.1
 
 license: MPL-2

--- a/src/fancyline/tty/dumb.cr
+++ b/src/fancyline/tty/dumb.cr
@@ -6,11 +6,11 @@ class Fancyline
         true
       end
 
-      def columns
+      def columns : Int32
         80
       end
 
-      def rows
+      def rows : Int32
         25
       end
 

--- a/src/fancyline/tty/vt100.cr
+++ b/src/fancyline/tty/vt100.cr
@@ -45,12 +45,12 @@ class Fancyline
         {% end %}
       end
 
-      def columns
-        winsize.try(&.ws_col) || ENV["COLUMNS"]?.try(&.to_i?) || 80
+      def columns : Int32
+        winsize.try(&.ws_col.to_i) || ENV["COLUMNS"]?.try(&.to_i?) || 80
       end
 
-      def rows
-        winsize.try(&.ws_row) || ENV["ROWS"]?.try(&.to_i?) || 25
+      def rows : Int32
+        winsize.try(&.ws_row.to_i) || ENV["ROWS"]?.try(&.to_i?) || 25
       end
 
       def prepare_line

--- a/src/fancyline/widget/history_search.cr
+++ b/src/fancyline/widget/history_search.cr
@@ -75,7 +75,7 @@ class Fancyline
         if editor.empty?
           @matches.clear
         else
-          @matches = history.lines.grep needle_regex
+          @matches = history.lines.select needle_regex
         end
 
         @position = 0


### PR DESCRIPTION
A couple of the more recent Crystal updates regarding abstract classes were causing warnings to be thrown, so I added explicit return values to a couple of the methods for the classes that are extending TTY

Edit: Tried running samples and noticed some more things were broken, so I fixed those too. Specs pass, but I'm not sure if there's anything else.