### PR TITLE
Add ^H to default key handlers to imitate backspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Possible improvement: Try to add better highlighting.
 
 One thing that's really useful is being able to pull up the man-page of the
 command you're currently working on without having to type it yourself.  We add
-a key-binding for `Ctrl-H` (`^H`) to do this for us:
+a key-binding for `Ctrl-O` (`^O`) to do this for us:
 
 ```crystal
 def get_command(ctx)
@@ -131,7 +131,7 @@ def get_command(ctx)
   line.split.first?
 end
 
-fancy.actions.set Fancyline::Key::Control::CtrlH do |ctx|
+fancy.actions.set Fancyline::Key::Control::CtrlO do |ctx|
   if command = get_command(ctx) # Figure out the current command
     system("man #{command}") # And open the man-page of it
   end

--- a/samples/tutorial/step3.cr
+++ b/samples/tutorial/step3.cr
@@ -1,11 +1,11 @@
 require "../../src/fancyline"
 
 # Step 3 of the usage tutorial:
-#   We add a custom key binding: When the user hits `Ctrl-H` (Or `^H`), we want
+#   We add a custom key binding: When the user hits `Ctrl-O` (Or `^O`), we want
 #   to open the man-page of the currently input command.
 
 fancy = Fancyline.new
-puts "Press Ctrl-C or Ctrl-D to quit.  Press Ctrl-H for man page."
+puts "Press Ctrl-C or Ctrl-D to quit.  Press Ctrl-O for man page."
 
 # This method grabs the current method from the line buffer with respect to the
 # cursor position.
@@ -19,7 +19,7 @@ def get_command(ctx)
 end
 
 # Listen for `Ctrl-H`
-fancy.actions.set Fancyline::Key::Control::CtrlH do |ctx|
+fancy.actions.set Fancyline::Key::Control::CtrlO do |ctx|
   if command = get_command(ctx) # Figure out the current command
     system("man #{command}")    # And open the man-page of it
   end

--- a/src/fancyline/key_action.cr
+++ b/src/fancyline/key_action.cr
@@ -19,6 +19,12 @@ class Fancyline
       Key::Control::Backspace => ->(ctx : Context) do
         ctx.editor.remove_at_cursor -1
       end,
+      # Add ^H as backspace to cover all possible keycodes
+      # see https://invisible-island.net/xterm/xterm.faq.html#xterm_erase
+      # and https://unix.stackexchange.com/questions/303016/backspace-not-working-in-kali-linux-terminal-hosted-on-backbox-using-virtual-box
+      Key::Control::CtrlH => ->(ctx : Context) do
+        ctx.editor.remove_at_cursor -1
+      end,
       Key::Control::Delete => ->(ctx : Context) do
         ctx.editor.remove_at_cursor +1
       end,


### PR DESCRIPTION
Depending on the system configuration, backspace is either `^?` or `^H`, this change adds `^H` to imitate the default behavior of `^?`. AFAIK, there is no collision here, as I use `^H` in conjunction with backspace (`^?` on my system) all the time.

Closes #9 