### PR TITLE
Ignore built samples and generated docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /doc/
+/docs/
 /lib/
 /bin/
 /.shards/
@@ -8,3 +9,5 @@
 /shard.lock
 
 history.log
+
+*.dwarf


### PR DESCRIPTION
Hi,

Most of this is just to remove noise in git from built samples, but the docs one is because `crystal docs` builds to that directory. Perhaps it's helpful.

Regards,
iain