### PR TITLE
Position in the search now correctly updates in the prompt.

### DIFF
--- a/src/fancyline/widget/history_search.cr
+++ b/src/fancyline/widget/history_search.cr
@@ -79,7 +79,6 @@ class Fancyline
         end
 
         @position = 0
-        editor.prompt = search_prompt
         move_entry ctx, -1
       end
 
@@ -110,6 +109,7 @@ class Fancyline
           ctx.editor.line = @matches[@position]
           ctx.editor.cursor = ctx.editor.line.size
         end
+        editor.prompt = search_prompt
       end
     end
   end


### PR DESCRIPTION
I noticed that cycling through returned matches wasn't updating
`@position`, so I've moved the prompt update (`search_prompt`)
into `move_entry` because it wasn't being called consistently, while `update_results` also calls `move_entry`.

fix: Prompt position in search wasn't updating, fixed.